### PR TITLE
When the user uses `st2 pack config` it will set the config to null instead of None

### DIFF
--- a/actions/base/action.py
+++ b/actions/base/action.py
@@ -21,7 +21,7 @@ class BaseExchangeAction(Action):
         self.timezone = EWSTimeZone.timezone(config['timezone'])
         try:
             server = config['server']
-            autodiscover = False
+            autodiscover = False if server is not None else True
         except KeyError:
             autodiscover = True
         cache = self._get_cache()

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -19,7 +19,7 @@ class ItemSensor(PollingSensor):
         self.sensor_folder = config['sensor_folder']
         try:
             self.server = config['server']
-            self.autodiscover = False
+            self.autodiscover = False if self.server is not None else True
         except KeyError:
             self.autodiscover = True
 


### PR DESCRIPTION
this guards the sensor or the action from bad values