### PR TITLE
MSExchange New Item Sensor Fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.1.4
+
+* Corrected timestamp handling functions in item_sensor
+* Added poll_interval configuration option for item_sensor
+* Added dispatch trigger function with logic to process new item object properties in item_sensor
+* Updated polling logic in item_sensor to update "READ" status on all new items
+* Corrected version pinning in requirements.txt file - 1.10.0
+
 ## 0.1.3
 
 * Set default folder to `Inbox` for `search_items`

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - calendar
   - exchange
   - office365
-version: 0.1.4
+version: 0.1.5
 author: "Anthony Shaw"
 email: anthonyshaw@apache.org
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-exchangelib>=1.9.3,<=1.10.1
+exchangelib>=1.9.3,<=1.10.0

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -6,8 +6,9 @@ from exchangelib import Account, ServiceAccount, Configuration, DELEGATE, EWSDat
 
 
 class ItemSensor(PollingSensor):
-    def __init__(self, sensor_service, config):
-        super(ItemSensor, self).__init__(sensor_service=sensor_service, config=config)
+    def __init__(self, sensor_service,config=None, poll_interval=None):
+        super(ItemSensor, self).__init__(sensor_service=sensor_service, config=config,
+                                         poll_interval=poll_interval)
         self._logger = self.sensor_service.get_logger(name=self.__class__.__name__)
         self._stop = False
         self._store_key = 'exchange.item_sensor_date_str'
@@ -55,6 +56,9 @@ class ItemSensor(PollingSensor):
             self._logger.info("Sending trigger for item '{0}'.".format(newitem.subject))
             self._dispatch_trigger_for_new_item(newitem=newitem)
             self._set_last_date(newitem.datetime_received)
+            self._logger.info("Updating read status on item '{0}'.".format(newitem.subject))
+            newitem.is_read = True
+            newitem.save()
 
     def cleanup(self):
         # This is called when the st2 system goes down. You can perform cleanup operations like

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -89,7 +89,7 @@ class ItemSensor(PollingSensor):
                                        value=self._last_date)
 
     def _dispatch_trigger_for_new_item(self, newitem):
-        trigger = self._trigger_ref
+        trigger = 'exchange_new_item''
         if isinstance(newitem['datetime_received'], EWSDateTime):
             datetime_received = newitem['datetime_received'].strftime('%Y-%m-%dT%H:%M:%S')
         else:

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -42,7 +42,7 @@ class ItemSensor(PollingSensor):
 
     def poll(self):
         stored_date = self._get_last_date()
-        self._logger.info("Stored Date: {}".format(print(stored_date)))
+        self._logger.info("Stored Date: {}".format(stored_date))
         if not stored_date:
             stored_date = datetime.now()
         start_date = self._timezone.localize(EWSDateTime.from_datetime(stored_date))

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -78,6 +78,10 @@ class ItemSensor(PollingSensor):
         return time.strptime(self._last_date, '%Y-%m-%dT%H:%M:%S')
 
     def _set_last_date(self, last_date):
-        self._last_date = time.strftime('%Y-%m-%dT%H:%M:%S', last_date)
+        # Check if the last_date value is an EWSDateTime object
+        if isinstance(last_date, EWSDateTime):
+            self._last_date = last_date.strftime('%Y-%m-%dT%H:%M:%S')
+        else:
+            self._last_date = time.strftime('%Y-%m-%dT%H:%M:%S', last_date)
         self._sensor_service.set_value(name=self._store_key,
                                        value=self._last_date)

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -89,7 +89,7 @@ class ItemSensor(PollingSensor):
                                        value=self._last_date)
 
     def _dispatch_trigger_for_new_item(self, newitem):
-        trigger = 'exchange_new_item''
+        trigger = 'exchange_new_item'
         if isinstance(newitem['datetime_received'], EWSDateTime):
             datetime_received = newitem['datetime_received'].strftime('%Y-%m-%dT%H:%M:%S')
         else:

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -42,6 +42,7 @@ class ItemSensor(PollingSensor):
 
     def poll(self):
         stored_date = self._get_last_date()
+        self._logger.info("Stored Date:", print(stored_date))
         if not stored_date:
             stored_date = datetime.now()
         start_date = self._timezone.localize(EWSDateTime.from_datetime(stored_date))

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -51,10 +51,10 @@ class ItemSensor(PollingSensor):
 
         self._logger.info("Found {0} items".format(items.count()))
 
-        for item in items:
-            self._logger.info("Sending trigger for item '{0}'.".format(item['subject']))
-            self._dispatch_trigger_for_new_item(item=item)
-            self._set_last_date(item['datetime_received'])
+        for newitem in items:
+            self._logger.info("Sending trigger for item '{0}'.".format(newitem['subject']))
+            self._dispatch_trigger_for_new_item(newitem=newitem)
+            self._set_last_date(newitem['datetime_received'])
 
     def cleanup(self):
         # This is called when the st2 system goes down. You can perform cleanup operations like
@@ -88,17 +88,17 @@ class ItemSensor(PollingSensor):
         self._sensor_service.set_value(name=self._store_key,
                                        value=self._last_date)
 
-    def _dispatch_trigger_for_new_item(self, item):
+    def _dispatch_trigger_for_new_item(self, newitem):
         trigger = self._trigger_ref
-        if isinstance(item['datetime_received'], EWSDateTime):
-            datetime_received = item['datetime_received'].strftime('%Y-%m-%dT%H:%M:%S')
+        if isinstance(newitem['datetime_received'], EWSDateTime):
+            datetime_received = newitem['datetime_received'].strftime('%Y-%m-%dT%H:%M:%S')
         else:
-            datetime_received = item['datetime_received']
+            datetime_received = newitem['datetime_received']
 
         payload = {
-            'item_id': str(item['item_id']),
-            'subject': str(item['subject']),
-            'body': str(item['body']),
+            'item_id': str(newitem['item_id']),
+            'subject': str(newitem['subject']),
+            'body': str(newitem['body']),
             'datetime_received': datetime_received,
         }
         self._sensor_service.dispatch(trigger=trigger, payload=payload)

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -6,7 +6,7 @@ from exchangelib import Account, ServiceAccount, Configuration, DELEGATE, EWSDat
 
 
 class ItemSensor(PollingSensor):
-    def __init__(self, sensor_service,config=None, poll_interval=None):
+    def __init__(self, sensor_service, config=None, poll_interval=None):
         super(ItemSensor, self).__init__(sensor_service=sensor_service, config=config,
                                          poll_interval=poll_interval)
         self._logger = self.sensor_service.get_logger(name=self.__class__.__name__)

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -50,6 +50,7 @@ class ItemSensor(PollingSensor):
         items = target.filter(is_read=False).filter(datetime_received__gt=start_date)
 
         self._logger.info("Found {0} items".format(items.count()))
+
         for payload in items.values('item_id', 'subject', 'body', 'datetime_received'):
             self._logger.info("Sending trigger for item '{0}'.".format(payload['subject']))
             self._sensor_service.dispatch(trigger='exchange_new_item', payload=payload)
@@ -76,7 +77,7 @@ class ItemSensor(PollingSensor):
         self._last_date = self._sensor_service.get_value(name=self._store_key)
         if self._last_date is None:
             return None
-        return time.strptime(self._last_date, '%Y-%m-%dT%H:%M:%S')
+        return datetime.strptime(self._last_date, '%Y-%m-%dT%H:%M:%S')
 
     def _set_last_date(self, last_date):
         # Check if the last_date value is an EWSDateTime object

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -89,7 +89,7 @@ class ItemSensor(PollingSensor):
                                        value=self._last_date)
 
     def _dispatch_trigger_for_new_item(self, newitem):
-        trigger = 'exchange_new_item'
+        trigger = 'msexchange.exchange_new_item'
         if isinstance(newitem.datetime_received, EWSDateTime):
             datetime_received = newitem.datetime_received.strftime('%Y-%m-%dT%H:%M:%S')
         else:

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -42,7 +42,7 @@ class ItemSensor(PollingSensor):
 
     def poll(self):
         stored_date = self._get_last_date()
-        self._logger.info("Stored Date:", print(stored_date))
+        self._logger.info("Stored Date: {}".format(print(stored_date)))
         if not stored_date:
             stored_date = datetime.now()
         start_date = self._timezone.localize(EWSDateTime.from_datetime(stored_date))

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -52,9 +52,9 @@ class ItemSensor(PollingSensor):
         self._logger.info("Found {0} items".format(items.count()))
 
         for newitem in items:
-            self._logger.info("Sending trigger for item '{0}'.".format(newitem['subject']))
+            self._logger.info("Sending trigger for item '{0}'.".format(newitem.subject))
             self._dispatch_trigger_for_new_item(newitem=newitem)
-            self._set_last_date(newitem['datetime_received'])
+            self._set_last_date(newitem.datetime_received)
 
     def cleanup(self):
         # This is called when the st2 system goes down. You can perform cleanup operations like
@@ -90,15 +90,15 @@ class ItemSensor(PollingSensor):
 
     def _dispatch_trigger_for_new_item(self, newitem):
         trigger = 'exchange_new_item'
-        if isinstance(newitem['datetime_received'], EWSDateTime):
-            datetime_received = newitem['datetime_received'].strftime('%Y-%m-%dT%H:%M:%S')
+        if isinstance(newitem.datetime_received, EWSDateTime):
+            datetime_received = newitem.datetime_received.strftime('%Y-%m-%dT%H:%M:%S')
         else:
-            datetime_received = newitem['datetime_received']
+            datetime_received = str(newitem.datetime_received)
 
         payload = {
-            'item_id': str(newitem['item_id']),
-            'subject': str(newitem['subject']),
-            'body': str(newitem['body']),
+            'item_id': str(newitem.item_id),
+            'subject': str(newitem.subject),
+            'body': str(newitem.body),
             'datetime_received': datetime_received,
         }
         self._sensor_service.dispatch(trigger=trigger, payload=payload)

--- a/sensors/item_sensor.yaml
+++ b/sensors/item_sensor.yaml
@@ -17,4 +17,5 @@ trigger_types:
           body:
             type: "string"
           datetime_received:
+            type: "string"
 

--- a/sensors/item_sensor.yaml
+++ b/sensors/item_sensor.yaml
@@ -10,12 +10,12 @@ trigger_types:
     payload_schema:
       type: "object"
       properties:
-          item_id:
-            type: "string"
-          subject:
-            type: "string"
-          body:
-            type: "string"
-          datetime_received:
-            type: "string"
+        item_id:
+          type: "string"
+        subject:
+          type: "string"
+        body:
+          type: "string"
+        datetime_received:
+          type: "string"
 

--- a/sensors/item_sensor.yaml
+++ b/sensors/item_sensor.yaml
@@ -17,4 +17,4 @@ trigger_types:
           body:
             type: "string"
           datetime_received:
-            type: "string"
+

--- a/sensors/item_sensor.yaml
+++ b/sensors/item_sensor.yaml
@@ -2,7 +2,7 @@
 class_name: "ItemSensor"
 entry_point: "item_sensor.py"
 description: "Sensor that detects items."
-polling_interval: 60
+poll_interval: 60
 trigger_types:
   -
     name: "exchange_new_item"


### PR DESCRIPTION
Corrected issues with the MSExchange sensor that were preventing it from functioning properly, including:

- Modified _set_last_date function used to store time stamp data to check and process EWSDateTime object returned on new items
- Added poll_interval configuration option
- Added function to process new item data returned from Exchange server and to convert "exchangelib" objects to text data before dispatching trigger
- Updated polling logic to call trigger function and to set the status of the item to "READ" so each new item only generates a single trigger
- Corrected version pinning in requirements.txt file so the virtualenv uses the correct version of exchangelib - 1.10.0 and not 1.10.1.