### PR TITLE
Remove date checking from item_sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 
 # VS Code project settings
 .vscode
+
+# Jetbrains project settings
+.idea

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.1.2
+* Remove date checking from item_sensor
+
 ## 1.1.0
 
 * **Add** `save_attachments` action.

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,10 +7,11 @@ keywords:
   - calendar
   - exchange
   - office365
-version: 1.1.1
+version: 1.1.2
 author: "Anthony Shaw"
 email: anthonyshaw@apache.org
 contributors:
   - "Tim Jones <tdjones74021@yahoo.com>"
+  - "Dennis Whitney <dennis@irunasroot.com"
 python_versions:
   - "3"


### PR DESCRIPTION
This PR removes the datetime check from item sensor as it was not working properly to begin with. It was determined in #11 that this feature was unnecessary and no longer needed.

This is currently how I use this pack in my production environment with a custom fork of this repo.

Fixes and closes #11 
