### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 # Change Log
 
+## 1.1.3
+
+* Updated files to work with latest CI updates
+
 ## 1.1.2
+
 * Remove date checking from item_sensor
 
 ## 1.1.0

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - calendar
   - exchange
   - office365
-version: 1.1.2
+version: 1.1.3
 author: "Anthony Shaw"
 email: anthonyshaw@apache.org
 contributors:

--- a/sensors/item_sensor.py
+++ b/sensors/item_sensor.py
@@ -1,6 +1,3 @@
-from datetime import datetime
-import time
-
 from st2reactor.sensor.base import PollingSensor
 from exchangelib import Account, ServiceAccount, Configuration, DELEGATE, EWSDateTime, EWSTimeZone
 


### PR DESCRIPTION
Fixed files to work with latest CI updates

- `time` and `datetime` were imported but never used